### PR TITLE
fix: remove deprecated codecov package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,21 +4,19 @@
 #
 #    make upgrade
 #
-attrs==22.2.0
-    # via pytest
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 iniconfig==2.0.0
     # via pytest
 numpy==1.24.2
     # via pandas
-packaging==23.0
+packaging==23.1
     # via pytest
-pandas==1.5.3
+pandas==2.0.0
     # via -r requirements/base.in
 pluggy==1.0.0
     # via pytest
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/base.in
     #   pytest-json-report
@@ -29,9 +27,11 @@ pytest-metadata==2.0.4
     # via pytest-json-report
 python-dateutil==2.8.2
     # via pandas
-pytz==2022.7.1
+pytz==2023.3
     # via pandas
 six==1.16.0
     # via python-dateutil
 tomli==2.0.1
     # via pytest
+tzdata==2023.3
+    # via pandas

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,29 +6,17 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   pytest
 build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.12.7
-    # via
-    #   -r requirements/travis.txt
-    #   requests
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==3.1.0
-    # via
-    #   -r requirements/travis.txt
-    #   requests
 click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
@@ -45,13 +33,9 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/travis.txt
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/quality.txt
-    #   -r requirements/travis.txt
-    #   codecov
     #   pytest-cov
 diff-cover==7.5.0
     # via -r requirements/dev.in
@@ -69,21 +53,17 @@ django==3.2.18
     #   edx-i18n-tools
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/quality.txt
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.9.0
+filelock==3.11.0
     # via
     #   -r requirements/travis.txt
     #   tox
     #   virtualenv
-idna==3.4
-    # via
-    #   -r requirements/travis.txt
-    #   requests
 iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
@@ -113,7 +93,7 @@ numpy==1.24.2
     # via
     #   -r requirements/quality.txt
     #   pandas
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -121,7 +101,7 @@ packaging==23.0
     #   build
     #   pytest
     #   tox
-pandas==1.5.3
+pandas==2.0.0
     # via -r requirements/quality.txt
 path==16.6.0
     # via edx-i18n-tools
@@ -129,9 +109,9 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.0
+platformdirs==3.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
@@ -154,9 +134,9 @@ pycodestyle==2.10.0
     # via -r requirements/quality.txt
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.0
     # via diff-cover
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -180,7 +160,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -205,7 +185,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   django
@@ -215,10 +195,6 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-requests==2.28.2
-    # via
-    #   -r requirements/travis.txt
-    #   codecov
 six==1.16.0
     # via
     #   -r requirements/quality.txt
@@ -251,7 +227,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -267,15 +243,15 @@ typing-extensions==4.5.0
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.14
+tzdata==2023.3
     # via
-    #   -r requirements/travis.txt
-    #   requests
-virtualenv==20.20.0
+    #   -r requirements/quality.txt
+    #   pandas
+virtualenv==20.21.0
     # via
     #   -r requirements/travis.txt
     #   tox
-wheel==0.38.4
+wheel==0.40.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,10 +6,6 @@
 #
 alabaster==0.7.13
     # via sphinx
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 babel==2.12.1
     # via sphinx
 bleach==6.0.0
@@ -24,7 +20,7 @@ click==8.1.3
     #   code-annotations
 code-annotations==1.3.0
     # via -r requirements/test.txt
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -38,7 +34,7 @@ docutils==0.19
     #   sphinx
 edx-sphinx-theme==3.1.0
     # via -r requirements/doc.in
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -46,7 +42,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via sphinx
 iniconfig==2.0.0
     # via
@@ -65,12 +61,12 @@ numpy==1.24.2
     # via
     #   -r requirements/test.txt
     #   pandas
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
     #   sphinx
-pandas==1.5.3
+pandas==2.0.0
     # via -r requirements/test.txt
 pbr==5.11.1
     # via
@@ -80,12 +76,12 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   readme-renderer
     #   sphinx
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -110,7 +106,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel
@@ -165,7 +161,11 @@ tomli==2.0.1
     #   coverage
     #   doc8
     #   pytest
-urllib3==1.26.14
+tzdata==2023.3
+    # via
+    #   -r requirements/test.txt
+    #   pandas
+urllib3==1.26.15
     # via requests
 webencodings==0.5.1
     # via bleach

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,15 +8,15 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
     # via build
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,14 +4,10 @@
 #
 #    make upgrade
 #
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 click==8.1.3
     # via
     #   -r requirements/test.txt
@@ -24,15 +20,15 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 dill==0.3.6
     # via pylint
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/quality.in
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -60,17 +56,17 @@ numpy==1.24.2
     # via
     #   -r requirements/test.txt
     #   pandas
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
-pandas==1.5.3
+pandas==2.0.0
     # via -r requirements/test.txt
 pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.1.0
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -80,7 +76,7 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -94,7 +90,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -119,7 +115,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   pandas
@@ -148,11 +144,15 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
+tzdata==2023.3
+    # via
+    #   -r requirements/test.txt
+    #   pandas
 wrapt==1.15.0
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,13 @@
 #
 #    make upgrade
 #
-attrs==22.2.0
-    # via
-    #   -r requirements/base.txt
-    #   pytest
 click==8.1.3
     # via code-annotations
 code-annotations==1.3.0
     # via -r requirements/test.in
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via pytest-cov
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/base.txt
     #   pytest
@@ -30,11 +26,11 @@ numpy==1.24.2
     # via
     #   -r requirements/base.txt
     #   pandas
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/base.txt
     #   pytest
-pandas==1.5.3
+pandas==2.0.0
     # via -r requirements/base.txt
 pbr==5.11.1
     # via stevedore
@@ -42,7 +38,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/base.txt
     #   pytest
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/base.txt
     #   pytest-cov
@@ -65,7 +61,7 @@ python-dateutil==2.8.2
     #   pandas
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   pandas
@@ -84,3 +80,7 @@ tomli==2.0.1
     #   -r requirements/base.txt
     #   coverage
     #   pytest
+tzdata==2023.3
+    # via
+    #   -r requirements/base.txt
+    #   pandas

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -1,6 +1,5 @@
 # Requirements for running tests in Travis
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,32 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/travis.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.0
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/travis.in
-urllib3==1.26.14
-    # via requests
-virtualenv==20.20.0
+virtualenv==20.21.0
     # via tox


### PR DESCRIPTION
### Description
- `codecov` package was deprecated and has now been removed from PyPI which is causing the upgrade PRs to fail
- Removed the package from requirements to fix the failing upgrade requirements job.