### PR TITLE
fix: enable updating pip.txt in make upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!
-	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --allow-unsafe --rebuild --upgrade -o requirements/pip.txt requirements/pip.in
 	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,11 +8,11 @@ exceptiongroup==1.1.1
     # via pytest
 iniconfig==2.0.0
     # via pytest
-numpy==1.24.2
+numpy==1.24.3
     # via pandas
 packaging==23.1
     # via pytest
-pandas==2.0.0
+pandas==2.0.1
     # via -r requirements/base.in
 pluggy==1.0.0
     # via pytest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -33,7 +33,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -89,7 +89,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   -r requirements/quality.txt
     #   pandas
@@ -101,7 +101,7 @@ packaging==23.1
     #   build
     #   pytest
     #   tox
-pandas==2.0.0
+pandas==2.0.1
     # via -r requirements/quality.txt
 path==16.6.0
     # via edx-i18n-tools
@@ -111,7 +111,7 @@ pbr==5.11.1
     #   stevedore
 pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/travis.txt
@@ -136,7 +136,7 @@ pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.15.1
     # via diff-cover
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -227,7 +227,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -247,7 +247,7 @@ tzdata==2023.3
     # via
     #   -r requirements/quality.txt
     #   pandas
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via
     #   -r requirements/travis.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,7 +20,7 @@ click==8.1.3
     #   code-annotations
 code-annotations==1.3.0
     # via -r requirements/test.txt
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -42,7 +42,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.5.0
+importlib-metadata==6.6.0
     # via sphinx
 iniconfig==2.0.0
     # via
@@ -57,7 +57,7 @@ markupsafe==2.1.2
     # via
     #   -r requirements/test.txt
     #   jinja2
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   -r requirements/test.txt
     #   pandas
@@ -66,7 +66,7 @@ packaging==23.1
     #   -r requirements/test.txt
     #   pytest
     #   sphinx
-pandas==2.0.0
+pandas==2.0.1
     # via -r requirements/test.txt
 pbr==5.11.1
     # via
@@ -117,7 +117,7 @@ pyyaml==6.0
     #   code-annotations
 readme-renderer==37.3
     # via -r requirements/doc.in
-requests==2.28.2
+requests==2.29.0
     # via sphinx
 restructuredtext-lint==1.4.0
     # via doc8

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.36.2
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.1.1
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==56.2.0
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
@@ -20,7 +20,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -52,7 +52,7 @@ markupsafe==2.1.2
     #   jinja2
 mccabe==0.7.0
     # via pylint
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   -r requirements/test.txt
     #   pandas
@@ -60,13 +60,13 @@ packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
-pandas==2.0.0
+pandas==2.0.1
     # via -r requirements/test.txt
 pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -76,7 +76,7 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -144,7 +144,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via code-annotations
 code-annotations==1.3.0
     # via -r requirements/test.in
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via pytest-cov
 exceptiongroup==1.1.1
     # via
@@ -22,7 +22,7 @@ jinja2==3.1.2
     # via code-annotations
 markupsafe==2.1.2
     # via jinja2
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   -r requirements/base.txt
     #   pandas
@@ -30,7 +30,7 @@ packaging==23.1
     # via
     #   -r requirements/base.txt
     #   pytest
-pandas==2.0.0
+pandas==2.0.1
     # via -r requirements/base.txt
 pbr==5.11.1
     # via stevedore

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ filelock==3.12.0
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -29,5 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/travis.in
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via tox


### PR DESCRIPTION
## Description
- `pip.txt` wasn't being updated in the `make upgrade` job because the `--upgrade` flag was missing in the `pip-compile` command
- It was causing the scheduled `Python Requirements Upgrade` [build](https://github.com/openedx/edx-django-utils/actions/runs/4847705622/jobs/8666288926#step:5:28) to fail due to `pip & pip-tools` conflict.