### PR TITLE
fix: remove tox-battery requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/doc.txt requirements/doc.in
 	$(PIP_COMPILE) -o requirements/quality.txt requirements/quality.in
-	$(PIP_COMPILE) -o requirements/travis.txt requirements/travis.in
+	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django version for tests
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,4 +2,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -20,19 +26,13 @@ platformdirs==4.1.0
     #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==3.28.0
-    # via
-    #   -r requirements/travis.in
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/travis.in
+tox==4.11.4
+    # via -r requirements/ci.in
 virtualenv==20.25.0
     # via tox

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,7 +3,7 @@
 
 -r pip-tools.txt          # pip-tools and its dependencies, for managing requirements files
 -r quality.txt            # Core and quality check dependencies
--r travis.txt             # tox and related dependencies
+-r ci.txt             # tox and related dependencies
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,8 +15,15 @@ build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+cachetools==5.3.2
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 chardet==5.2.0
-    # via diff-cover
+    # via
+    #   -r requirements/ci.txt
+    #   diff-cover
+    #   tox
 click==8.1.7
     # via
     #   -r requirements/pip-tools.txt
@@ -33,6 +40,10 @@ code-annotations==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 coverage[toml]==7.3.2
     # via
     #   -r requirements/quality.txt
@@ -46,7 +57,7 @@ dill==0.3.7
     #   pylint
 distlib==0.3.7
     # via
-    #   -r requirements/travis.txt
+    #   -r requirements/ci.txt
     #   virtualenv
 django==3.2.23
     # via
@@ -62,7 +73,7 @@ exceptiongroup==1.2.0
     #   pytest
 filelock==3.13.1
     # via
-    #   -r requirements/travis.txt
+    #   -r requirements/ci.txt
     #   tox
     #   virtualenv
 importlib-metadata==7.0.0
@@ -98,10 +109,11 @@ numpy==1.24.4
     #   pandas
 packaging==23.2
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
-    #   -r requirements/travis.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   tox
 pandas==2.0.3
@@ -116,23 +128,20 @@ pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
 platformdirs==4.1.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   -r requirements/travis.txt
     #   pylint
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   -r requirements/travis.txt
     #   diff-cover
     #   pytest
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-py==1.11.0
-    # via
-    #   -r requirements/travis.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/quality.txt
 pydocstyle==6.3.0
@@ -159,6 +168,10 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
@@ -201,10 +214,8 @@ pyyaml==6.0.1
 six==1.16.0
     # via
     #   -r requirements/quality.txt
-    #   -r requirements/travis.txt
     #   edx-lint
     #   python-dateutil
-    #   tox
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
@@ -221,13 +232,14 @@ text-unidecode==1.3
     #   python-slugify
 tomli==2.0.1
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
-    #   -r requirements/travis.txt
     #   build
     #   coverage
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
@@ -235,12 +247,8 @@ tomlkit==0.12.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.28.0
-    # via
-    #   -r requirements/travis.txt
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/travis.txt
+tox==4.11.4
+    # via -r requirements/ci.txt
 typing-extensions==4.8.0
     # via
     #   -r requirements/quality.txt
@@ -253,7 +261,7 @@ tzdata==2023.3
     #   pandas
 virtualenv==20.25.0
     # via
-    #   -r requirements/travis.txt
+    #   -r requirements/ci.txt
     #   tox
 wheel==0.42.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -61,7 +61,7 @@ markupsafe==2.1.3
     # via
     #   -r requirements/test.txt
     #   jinja2
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
 numpy==1.24.4
     # via


### PR DESCRIPTION
## Description
- Remove `tox-battery` requirement as it is not needed for `tox>4` anymore.