### PR TITLE
docs: add arbi-bom team as maintainer

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -14,6 +14,7 @@ jobs:
     with:
        branch: ${{ github.event.inputs.branch }}
        send_success_notification: false
+       team_reviewers: "arbi-bom"
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'pytest-warnings-report'
+  description: "A pytest plugin for generating warnings reports."
+  links:
+    - url: "https://github.com/openedx/pytest-warnings-report"
+      title: "A pytest plugin for generating warnings reports."
+      icon: "Web"
+  annotations:
+    openedx.org/arch-interest-groups: ""
+spec:
+  owner: group:2u-arbi-bom
+  type: 'other'
+  lifecycle: 'production'


### PR DESCRIPTION
## Description
- As per the discussion in Maintenance working group, `arbi-bom` team will maintain this repo from now on. 